### PR TITLE
Remove ENV WINEARCH win32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:lts-bullseye
 
-ENV WINEARCH win32
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends apt-transport-https zip unzip
 


### PR DESCRIPTION
Your problem is this line:

https://github.com/electron/node-rcedit/blob/master/lib/rcedit.js#L9

Which is selecting the 64-bit architecture, based upon this code:

https://github.com/malept/cross-spawn-windows-exe/blob/main/src/arch.ts

And causing your nightly builds to implode because win64 is not available:

https://gitlab.com/CoMiGo/ct-js/-/jobs/3058372527

Your WINE installation is pretty [by-the-book](https://linuxhint.com/install-winehq-on-ubuntu-20-04/) (see _Installing “wineHQ” Via Wine Build Repository_) and once upon a time there were a lot of hoops to jump through to get 64-bit WINE. But - with a bit of luck - that's no longer the case.

If this doesn't work there are a few other options available to us:

* Try `ENV WINEARCH win64` instead - I believe it defaults to this anyway but we can see
* Try `&& apt-get install -y wine-stable && apt-get install -y wine-stable-amd64 && apt-get install -y wine-stable-win32` on line 19
* `cp -f ./node_modules/rcedit/bin/rcedit.exe ./node_modules/rcedit/bin/rcedit-x64.exe` after `npm install`
* `Object.defineProperty(process, 'arch', { value: 'blah' })` - option of last resort